### PR TITLE
Update apiKey to appid

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -8,7 +8,7 @@ exports.sourceNodes = async (
   { plugins, ...options }
 ) => {
 
-  const apiUrl = `https://api.openweathermap.org/data/2.5/${options.type}?q=${options.location}&units=${options.units}&apikey=${options.apikey}`;
+  const apiUrl = `https://api.openweathermap.org/data/2.5/${options.type}?q=${options.location}&units=${options.units}&appid=${options.apikey}`;
   const response = await fetch(apiUrl);
   const data = await response.json();
 


### PR DESCRIPTION
The OpenWeather updated its API access to use `appid` instead of `apiKey` https://openweathermap.org/guide#api